### PR TITLE
Add "Serge AI Chat" to list of roles

### DIFF
--- a/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/nas.yml
+++ b/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/nas.yml
@@ -404,6 +404,11 @@
         - sabnzbd
       when: (sabnzbd_enabled | default(False))
 
+    - role: serge
+      tags:
+        - serge
+      when: (serge_enabled | default(False))
+
     - role: sickchill
       tags:
         - sickchill

--- a/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/roles/serge/defaults/main.yml
+++ b/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/roles/serge/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+serge_enabled: false
+serge_available_externally: false
+
+# directories
+serge_data_directory: "{{ docker_home }}/serge/config"
+
+# uid / gid
+serge_user_id: "0"
+serge_group_id: "0"
+
+# network
+serge_port: "8008"
+serge_hostname: "serge"
+serge_container_name: "{{ serge_hostname }}"

--- a/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/roles/serge/tasks/main.yml
+++ b/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/roles/serge/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Create Serge AI Chat Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ serge_data_directory }}"
+
+- name: Serge AI Chat
+  docker_container:
+    name: "{{ serge_container_name }}"
+    image: ghcr.io/serge-chat/serge:latest
+    pull: true
+    volumes:
+      - "{{ serge_data_directory }}:/config:rw"
+      - "{{ serge_data_directory }}/weights:/usr/src/app/weights:rw"
+      - "{{ serge_data_directory }}/datadb:/data/db/:rw"
+    ports:
+      - "{{ serge_port }}:{{ serge_port }}"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ serge_user_id }}"
+      PGID: "{{ serge_group_id }}"
+    restart_policy: unless-stopped
+    labels:
+      traefik.enable: "{{ serge_available_externally | string }}"
+      traefik.http.routers.serge.rule: "Host(`{{ serge_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.serge.tls.certresolver: "letsencrypt"
+      traefik.http.routers.serge.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.serge.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.serge.loadbalancer.server.port: "{{ serge_port }}"


### PR DESCRIPTION
Adding the self-hosted generative AI front-end, "[Serge](https://serge.chat/)" as one of the available Ansible roles for the "Ultimate DevOps NAS" host provisioning playbook