### PR TITLE
adding app external domain name as a trusted proxy

### DIFF
--- a/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/roles/firefly/tasks/main.yml
+++ b/code/environments/dev/init-ultimate-nas/config/ansible/ultimate-nas-deploy/roles/firefly/tasks/main.yml
@@ -50,6 +50,8 @@
           DB_USERNAME: "firefly"
           DB_PASSWORD: "firefly"
           TZ: "{{ ansible_nas_timezone }}"
+          APP_URL: "https://{{ firefly_hostname }}.{{ ansible_nas_domain }}"
+          TRUSTED_PROXIES: "*"
         restart_policy: unless-stopped
         memory : "{{ firefly_memory }}"
         labels:


### PR DESCRIPTION
external access to app was not working, needed to add reference to external domain name of service as a trusted proxy