### PR TITLE
excluding unimportant files from SnapRAID sync

### DIFF
--- a/code/environments/dev/init-ultimate-nas/config/ansible/drive-config/roles/snapraid/defaults/main.yml
+++ b/code/environments/dev/init-ultimate-nas/config/ansible/drive-config/roles/snapraid/defaults/main.yml
@@ -43,6 +43,12 @@ snapraid_excludes:
   - "*.unrecoverable"
   - /tmp/
   - /lost+found/
+  - "*.nfo"
+  - "*.part"
+  - "*.parts"
+  - "*.thumbs.db"
+  - "*.tmp"
+
 
 # Defines the block size in kibi bytes (1024 bytes)
 # snapraid_blocksize: 256


### PR DESCRIPTION
excluded the following files:

  - `"*.nfo"`
  - `"*.part"`
  - `"*.parts"`
  - `"*.thumbs.db"`
  - `"*.tmp"`